### PR TITLE
readme: fix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
    ```
 8. Run Deployment Test:
    ```txt
-   $ python run [PATHTOFILE]/scripts/test_SmartContractDeployment.py 
+   $ python scripts/test_SmartContractDeployment.py 
    ```
 
 When finished, the sandbox can be stopped with ./sandbox down


### PR DESCRIPTION
- There is no `run` subcommand
- The prior commands assume the root of the repo is CWD, so do the same here